### PR TITLE
Auto assign variant

### DIFF
--- a/api/digital-variants.php
+++ b/api/digital-variants.php
@@ -56,5 +56,6 @@ function it_exchange_digital_variants_addon_is_digital_variant( $product_id, $it
  * @return     true if variant is a digital variant, otherwise false
  */
 function it_exchange_digital_variants_addon_is_digital_variant_from_variant( $variant ) {
-	return ( IT_EXCHANGE_DIGITAL_VARIANTS_VARIANT_SLUG === $variant->post_name );
+	$addon_settings = it_exchange_get_option( IT_EXCHANGE_DIGITAL_VARIANTS_SETTINGS_KEY );
+	return ( $addon_settings['variant_id'] == $variant->ID );
 }

--- a/api/digital-variants.php
+++ b/api/digital-variants.php
@@ -16,7 +16,7 @@ define( 'IT_EXCHANGE_DIGITAL_VARIANTS_PHYSICAL_VARIANT_SLUG', 'print' );
 define( 'IT_EXCHANGE_DIGITAL_VARIANTS_PHYSICAL_VARIANT_TITLE', 'Print' );
 define( 'IT_EXCHANGE_DIGITAL_VARIANTS_VARIANT_DEFAULT', IT_EXCHANGE_DIGITAL_VARIANTS_PHYSICAL_VARIANT_SLUG );
 define( 'IT_EXCHANGE_DIGITAL_VARIANTS_VARIANT_UI_TYPE', 'select' );
-define( 'IT_EXCHANGE_DIGITAL_VARIANTS_VARIANT_VERSION', '0.0.31' );
+define( 'IT_EXCHANGE_DIGITAL_VARIANTS_SETTINGS_KEY', 'digital-variants-addon' );
 
 /**
  * Checks if the product is a digital variant of a physical product
@@ -39,11 +39,22 @@ function it_exchange_digital_variants_addon_is_digital_variant( $product_id, $it
 			$all_variant_values = it_exchange_get_values_for_variant( $variant );
 			foreach ( $all_variant_values as $value ) {
 				// ...And check if the value title matches the digital variant value title.
-				if ( ($value_id == $value->ID) && (IT_EXCHANGE_DIGITAL_VARIANTS_DIGITAL_VARIANT_TITLE === $value->title) ) {
+				if ( ($value_id == $value->ID) && (IT_EXCHANGE_DIGITAL_VARIANTS_DIGITAL_VARIANT_SLUG === $value->post_name ) ) {
 					return true;
 				}
 			}
 		}
 	}
 	return false;
+}
+
+/**
+ * @brief      Checks whether the provided variant is a digital variant
+ *
+ * @param      $variant  The variant object
+ *
+ * @return     true if variant is a digital variant, otherwise false
+ */
+function it_exchange_digital_variants_addon_is_digital_variant_from_variant( $variant ) {
+	return ( IT_EXCHANGE_DIGITAL_VARIANTS_VARIANT_SLUG === $variant->post_name );
 }

--- a/lib/addon-functions.php
+++ b/lib/addon-functions.php
@@ -23,7 +23,7 @@ function it_exchange_digital_variants_addon_is_digital_variant_from_data( $produ
 		$itemized_data = maybe_unserialize( $itemized_data );
 		if ( ! empty( $itemized_data['it_variant_combo_hash'] ) ) {
 			// Product is of a particular variant, get the attributes.
-			return it_exchange_digital_variants_addon_is_digital_variant( $product_id, $itemized_data['it_variant_combo_hash'] );
+			return it_exchange_digital_variants_addon_is_digital_variant_from_product( $product_id, $itemized_data['it_variant_combo_hash'] );
 		}
 	}
 	return false;

--- a/lib/required-hooks.php
+++ b/lib/required-hooks.php
@@ -71,7 +71,7 @@ function it_exchange_digital_variants_addon_create_digital_variant() {
  * @return     None
  */
 function it_exchange_digital_variants_addon_init() {
-	$addon_settings = it_exchange_get_option( IT_EXCHANGE_DIGITAL_VARIANTS_SETTINGS_KEY, true );
+	$addon_settings = it_exchange_get_option( IT_EXCHANGE_DIGITAL_VARIANTS_SETTINGS_KEY );
 
 	// Confirm that the option exists
 	if ( $addon_settings['variant_id'] ) {
@@ -89,6 +89,7 @@ function it_exchange_digital_variants_addon_init() {
 		it_exchange_save_option( IT_EXCHANGE_DIGITAL_VARIANTS_SETTINGS_KEY, $addon_settings );
 	}
 }
+add_action( 'admin_init', 'it_exchange_digital_variants_addon_init' );
 
 /**
  * Intercept attempts to discover if the product has downloads, and if it is not
@@ -216,13 +217,11 @@ function it_exchange_digital_variants_addon_save_with_variant( $product_id ) {
 	foreach ( $variants as $variant ) {
 		if ( it_exchange_digital_variants_addon_is_digital_variant_from_variant( $variant ) ) {
 			// The variant is already attached
-			skindeep_write_log("breaking early!");
 			return;
 		}
 	}
 
 	// We need to add the digital variant
-	// TODO: Check if digital variant was there but has been renamed...
 	$addon_settings = it_exchange_get_option( IT_EXCHANGE_DIGITAL_VARIANTS_SETTINGS_KEY );
 	$existing_variant_data['variants'][] = $addon_settings['variant_id'];
 

--- a/lib/required-hooks.php
+++ b/lib/required-hooks.php
@@ -20,45 +20,75 @@ function it_exchange_digital_variants_addon_add_features_to_digital_variant_prod
 add_action( 'it_exchange_enabled_addons_loaded', 'it_exchange_digital_variants_addon_add_features_to_digital_variant_products' );
 
 /**
- * Adds digital/physical variant presets
+ * @brief      Creates the digital variant that is shared by all digital variant products
  *
- * @since 0.1.0
- *
- * @return void
+ * @return     Variant ID
  */
-function it_exchange_digital_variants_addon_setup_preset_variants() {
-	// Check the preset hasn't already been added.
-	$existing_presets = it_exchange_variants_addon_get_presets(
-		array(
-			'core_only' => false,
-	));
-
-	if ( ! isset( $existing_presets['format'] ) ) {
-		// Create a preset variant for Digital/Print.
-		$format_preset = array(
-			'slug' => IT_EXCHANGE_DIGITAL_VARIANTS_VARIANT_SLUG,
-			'title' => IT_EXCHANGE_DIGITAL_VARIANTS_VARIANT_TITLE,
-			'values' => array(
-				'print' => array(
-					'slug' => IT_EXCHANGE_DIGITAL_VARIANTS_PHYSICAL_VARIANT_SLUG,
-					'title' => IT_EXCHANGE_DIGITAL_VARIANTS_PHYSICAL_VARIANT_TITLE,
-					'order' => 1,
-				),
-				'digital' => array(
-					'slug' => IT_EXCHANGE_DIGITAL_VARIANTS_DIGITAL_VARIANT_SLUG,
-					'title' => IT_EXCHANGE_DIGITAL_VARIANTS_DIGITAL_VARIANT_TITLE,
-					'order' => 2,
-				),
+function it_exchange_digital_variants_addon_create_digital_variant() {
+	// Construct the arguments for the variant (inc values)
+	$variant_args = array(
+		'parent' => array(
+			'post_title' => IT_EXCHANGE_DIGITAL_VARIANTS_VARIANT_TITLE,
+			'post_name' => IT_EXCHANGE_DIGITAL_VARIANTS_VARIANT_SLUG,
+			'ui_type' => IT_EXCHANGE_DIGITAL_VARIANTS_VARIANT_UI_TYPE,
+		),
+		'values' => array(
+			array(
+				'post_title' => IT_EXCHANGE_DIGITAL_VARIANTS_PHYSICAL_VARIANT_TITLE,
+				'post_name' => IT_EXCHANGE_DIGITAL_VARIANTS_PHYSICAL_VARIANT_SLUG,
 			),
-			'default' => IT_EXCHANGE_DIGITAL_VARIANTS_VARIANT_DEFAULT,
-			'core' => false,
-			'ui-type' => IT_EXCHANGE_DIGITAL_VARIANTS_VARIANT_UI_TYPE,
-			'version' => IT_EXCHANGE_DIGITAL_VARIANTS_VARIANT_VERSION,
-		);
-		it_exchange_variants_addon_create_variant_preset( $format_preset );
+			array(
+				'post_title' => IT_EXCHANGE_DIGITAL_VARIANTS_DIGITAL_VARIANT_TITLE,
+				'post_name' => IT_EXCHANGE_DIGITAL_VARIANTS_DIGITAL_VARIANT_SLUG,
+			),
+		),
+	);
+
+	// Create the variant
+	$variant_id = it_exchange_variants_addon_create_variant( $variant_args['parent'] );
+
+	// Create the values
+	foreach ( $variant_args['values'] as $value ) {
+		// Update the args with the variant
+		$value['post_parent'] = $variant_id;
+
+		// Create the variant value
+		$value_id = it_exchange_variants_addon_create_variant( $value );
+
+		// Set as default, if necessary
+		if ( IT_EXCHANGE_DIGITAL_VARIANTS_VARIANT_DEFAULT === $value['post_name'] ) {
+			// Update the parent with the default value
+			it_exchange_variants_addon_update_variant( $variant_id, array( 'default' => $value_id ) );
+		}
+	}
+
+	return $variant_id;
+}
+
+/**
+ * @brief      Ensures that there is a digital variant created and recorded
+ *
+ * @return     None
+ */
+function it_exchange_digital_variants_addon_init() {
+	$addon_settings = it_exchange_get_option( IT_EXCHANGE_DIGITAL_VARIANTS_SETTINGS_KEY, true );
+
+	// Confirm that the option exists
+	if ( $addon_settings['variant_id'] ) {
+		// Confirm that the variant exists
+		if ( it_exchange_variants_addon_get_variant( $addon_settings['variant_id'] ) ) {
+			// The variant has already been created
+			return;
+		}
+	}
+
+	// Create the digital variant and save its ID in the database
+	if ( $new_id = it_exchange_digital_variants_addon_create_digital_variant() ) {
+		// Create an option to the database
+		$addon_settings['variant_id'] = $new_id;
+		it_exchange_save_option( IT_EXCHANGE_DIGITAL_VARIANTS_SETTINGS_KEY, $addon_settings );
 	}
 }
-add_action( 'admin_init', 'it_exchange_digital_variants_addon_setup_preset_variants' );
 
 /**
  * Intercept attempts to discover if the product has downloads, and if it is not
@@ -164,3 +194,39 @@ add_filter(
 	'it_exchange_digital_variants_addon_get_available_shipping_methods_for_cart',
 	10,
 1);
+
+/**
+ * @brief      Updates the digital variant product to have the variant attached
+ *
+ * @param      $product_id  The product identifier
+ *
+ * @return     None
+ */
+function it_exchange_digital_variants_addon_save_with_variant( $product_id ) {
+	// Ensure that variants are enabled for the product
+	$existing_variant_data = (array) it_exchange_get_product_feature( $product_id, 'variants' );
+	if ( empty( $new_variant_data['enabled'] ) || 'no' == $new_variant_data['enabled'] ) {
+		$existing_variant_data['enabled'] = 'yes';
+	}
+
+	// Get any existing variants
+	$variants = (array) it_exchange_get_variants_for_product( $product_id );
+
+	// Ensure that the digital variant is among them
+	foreach ( $variants as $variant ) {
+		if ( it_exchange_digital_variants_addon_is_digital_variant_from_variant( $variant ) ) {
+			// The variant is already attached
+			skindeep_write_log("breaking early!");
+			return;
+		}
+	}
+
+	// We need to add the digital variant
+	// TODO: Check if digital variant was there but has been renamed...
+	$addon_settings = it_exchange_get_option( IT_EXCHANGE_DIGITAL_VARIANTS_SETTINGS_KEY );
+	$existing_variant_data['variants'][] = $addon_settings['variant_id'];
+
+	// Update
+	it_exchange_update_product_feature( $product_id, 'variants', $existing_variant_data );
+}
+add_action( 'it_exchange_save_product_digital-variant-product-type', 'it_exchange_digital_variants_addon_save_with_variant', 11);


### PR DESCRIPTION
- Creates a single **Format** variant in the database when the addon is activated.
- Automatically assigns the 'digital/physical' variant to products of type *digital_variant_product_type*, and enables variants for the product. All products share the same variant.

This means the variant options and values can be edited on any product page, and changes applied throughout the site.